### PR TITLE
Escape `<`, `>` and `/` in translation strings

### DIFF
--- a/find.php
+++ b/find.php
@@ -155,7 +155,7 @@ foreach($stripped as $index => $param)
 	    echo_nl2br("\nSearch for: \"".mb_substr($string, 0, 50)."[...]\" in \"$dir\", file \"$file\"\n");
 	    while($rec = fgets($fp)){
 		// check to see if the line contains the string
-		if (preg_match("/\b$string\b/", $rec) > 0){
+		if (preg_match("/\b" . preg_quote($string, '/') . "\b/", $rec) > 0){
 		    // if so copy the whole line into copy_strings file
 		    echo_nl2br("<green>=> Found \"".mb_substr($string, 0, 50)."[...]\" in file \"$file\". Queuing for copying. The full line is: $rec</close>");
 		    $total_files++;


### PR DESCRIPTION
Received tones of errors before:

```
Warning: preg_match(): Unknown modifier 't' in /home/nickv/ownCloud/master/core/find.php on line 158

Call Stack:
    0.0005     279560   1. {main}() /home/nickv/ownCloud/master/core/find.php:0
    0.1093     408568   2. preg_match() /home/nickv/ownCloud/master/core/find.php:158
```

`find_string` from master to stable8.2

```
"apps/encryption", "ownCloud basic encryption module"
"apps/encryption", "Hey there,\n\nthe admin enabled server-side-encryption. Your files were encrypted using the password '%s'.\n\nPlease login to the web interface, go to the section 'ownCloud basic encryption module' of your personal settings and update your encryption password by entering this password into the 'old log-in password' field and your current login-password.\n\n"
"apps/encryption", "Hey there,<br><br>the admin enabled server-side-encryption. Your files were encrypted using the password <strong>%s</strong>.<br><br>Please login to the web interface, go to the section \"ownCloud basic encryption module\" of your personal settings and update your encryption password by entering this password into the \"old log-in password\" field and your current login-password.<br><br>"
"apps/encryption", "Missing recovery key password"
"apps/encryption", "Please repeat the recovery key password"
"apps/encryption", "Invalid private key for Encryption App. Please update your private key password in your personal settings to recover access to your encrypted files." 
"apps/encryption", "The share will expire on %s."
"apps/encryption", "Cheers!"
"apps/encryption", "Enabled"
"apps/files", "Upload cancelled."
"apps/files", "{newname} already exists"
"apps/files", "Upload"
"apps/files", "There is no error, the file uploaded with success"
"apps/files", "Upload cancelled."
"apps/files", "Home"
"apps/files_external", "Enable User External Storage"
"apps/files_external", "Delete"
"apps/files_external", "Add storage"
"apps/files_external", "Builtin"
"apps/files_external", "Root"
"apps/files_external", "Allow users to mount the following external storage"
"apps/files_external", "Saved"
"apps/files_sharing", "Shared with you"
"apps/files_sharing", "Shared with others"
"apps/files_sharing", "Shared by link"
"apps/files_sharing", "Direct link"
"apps/files_sharing", "Federated Cloud Sharing"
"apps/files_trashbin", "Deleted"
"apps/files_trashbin", "Delete"
"apps/files_versions", "Failed to revert {file} to revision {timestamp}."
"apps/user_ldap", "When logging in, %s will find the user based on the following attributes:"
"apps/user_ldap", "Backup (Replica) Host"
"apps/user_ldap", "Give an optional backup host. It must be a replica of the main LDAP/AD server."
"apps/user_ldap", "Backup (Replica) Port"
"apps/user_ldap", "Settings verified, but one user found. Only the first will be able to login. Consider a more narrow filter."
"apps/user_ldap", "Verify settings and count users"
"apps/user_ldap", "The configuration is valid, but the Bind failed. Please check the server settings and credentials."
"apps/user_ldap", "An error occurred. Please check the Base DN, as well as connection settings and credentials."
"apps/user_ldap", "Mappings cleared successfully!"
"apps/user_ldap", "Error while clearing the mappings."
"apps/user_ldap", "User found and settings verified."
"apps/user_ldap", "An unspecified error occurred. Please check the settings and the log."
"apps/user_ldap", "A connection error to LDAP / AD occurred, please check host, port and credentials."
"apps/user_ldap", "Internal Username"
"core", "remember"
"core", "Choose a password for the public link"
"core", "Following incompatible apps have been disabled: %s"
"core", "Hey there,<br><br>just letting you know that %s shared <strong>%s</strong> with you.<br><a href=\"%s\">View it!</a><br><br>"
"core", "Migration tests are skipped - \"update.skip-migration-test\" is activated in config.php"
"core", "Log out"
"core", "%s will be updated to version %s"
"core", "These apps will be updated:"
"core", "Log in"
"lib", "Sharing %s failed, because the user %s is the item owner"
"lib", "Sharing %s failed, because the user %s is the original sharer"
"lib", "Sharing %s failed, because the sharing backend for %s could not find its source"
"lib", "today"
"lib", "%s shared »%s« with you"
"settings", "No apps found for your version"
"settings", "test email settings"
"settings", "Transactional file locking is using the database as locking backend, for best performance it's advised to configure a memcache for locking. See the <a target=\"_blank\" href=\"%s\">documentation ↗</a> for more information."
"settings", "Sync clients"
```
